### PR TITLE
Bootstraps: Adding bootstraps for CMS jobs execution [Webfest]

### DIFF
--- a/bootstraps/cms-webfest/bin/mcprod-monitor
+++ b/bootstraps/cms-webfest/bin/mcprod-monitor
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+#
+# Monitor the output logs of the job and update the
+# status information metadata
+#
+
+import time
+import sys
+import os
+
+# Include dumbq utilities library path from CVMFS
+sys.path.append( "/cvmfs/sft.cern.ch/lcg/external/experimental/dumbq/client/utils" )
+from dumbq.logmonitor import LogMonitorLogic, LogMonitor
+import dumbq.metrics as metrics
+
+# The path were the mcplots job output file should be located
+MCPLOTS_STDOUT_LOG = "/tmp/mcplots-job.out"
+MCPLOTS_CLONE_LOG = "/var/www/html/logs/job.out"
+
+class MCPlotsStdoutMonitor(LogMonitorLogic):
+	"""
+	MCPlots standard output log monitor
+	"""
+
+	def __init__(self):
+		"""
+		Initialize parser
+		"""
+		self.cloneFile = None
+		self.reset()
+
+	def reset(self):
+		"""
+		Reset monitor status
+		"""
+
+		# Close old file
+		if not self.cloneFile is None:
+			try:
+				self.cloneFile.close()
+			except Exception:
+				pass
+			self.cloneFile = None
+
+		# Open new log file
+		try:
+			self.cloneFile = open( MCPLOTS_CLONE_LOG, 'w' )
+		except Exception:
+			self.cloneFile = None
+
+		# Reset properties
+		self.inputParams = { }
+		self.state = 0
+		self.lastEventTs = 0
+		self.lastNevts = 0
+		self.eventRateRing = []
+
+		# Reset metrics
+		metrics.delete( "config" )
+		metrics.set( "progress", 0 )
+		metrics.set( "eventRate", 0 )
+
+	def parse(self, line):
+		"""
+		Parse a log file
+		"""
+
+		# Clone log
+		if not self.cloneFile is None:
+			self.cloneFile.write(line)
+			self.cloneFile.flush()
+
+		# Strip line
+		line = line.strip()
+
+		#
+		# (0 -> 1) Wait until we get 'Input parameters:'
+		#
+		if (self.state == 0) and ("Input parameters" in line):
+
+			# We are parsing input parameters
+			self.state = 1
+
+		#
+		# (2) Wait until we get 'Events processed'
+		#
+		if (self.state == 2) and ("Events processed" in line):
+
+			# Parse how many events are processed
+			parts = line.split(" ")
+			nevts = int(parts[0])
+
+			# Check if we have a last timestamp to calculate delta
+			if self.lastEventTs > 0:
+
+				# Calculate time delta
+				tDelta = time.time() - self.lastEventTs
+
+				# Calculate event delta
+				evDelta = nevts - self.lastNevts
+
+				# Protect against division by zero
+				if tDelta > 0:
+
+					# Calculate rate
+					rate = float(evDelta) / float(tDelta)
+
+					# Store on ring & trim
+					self.eventRateRing.append(rate)
+					while len(self.eventRateRing) > 10:
+						del self.eventRateRing[0]
+
+					# Calculate average rate
+					rate = sum(self.eventRateRing) / float(len(self.eventRateRing))
+					metrics.set( "eventRate", rate )
+
+			# Update last event timestamp
+			self.lastEventTs = time.time()
+			self.lastNevts = nevts
+
+			# Calculate progress
+			if 'nevts' in self.inputParams:
+
+				# Calculate progress
+				totalEvents = int(self.inputParams['nevts'])
+				progress = float(nevts) / float(totalEvents)
+
+				# Update progress
+				metrics.set( "progress", progress )
+
+		#
+		# (1) Parse 'Input parameters'
+		#
+		elif (self.state == 1):
+
+			# If we got an empty line, switch back to state 0
+			if not line:
+				# Switch to 'running state'
+				self.state = 2
+
+			else:
+				# Get key/value parameters
+				parts = line.split("=")
+				if len(parts) >= 2:
+					# Update input parameters
+					self.inputParams[parts[0]] = parts[1].strip()
+					# Update configuration metrics
+					metrics.set( "config/%s" % parts[0], parts[1].strip() )
+
+
+# Create a log monitor to monitor mcplots output file
+monitor = LogMonitor( )
+monitor.monitor( MCPLOTS_STDOUT_LOG, MCPlotsStdoutMonitor() )
+monitor.start()
+

--- a/bootstraps/cms-webfest/init.sh
+++ b/bootstraps/cms-webfest/init.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# CMS Job Execution For Webfest
+# (C) Copyright 2015, Jorge Vicente Cantero, Ioannis Charalampidis, PH/SFT, CERN
+#
+
+# Configuration parameters
+BOOTSTRAP_NAME="cms-webfest"
+BOOTSTRAP_VER="1"
+
+# Paths for executables
+DUMBQ_DIR="/cvmfs/sft.cern.ch/lcg/external/experimental/dumbq"
+BOOTSTRAP_DIR="${DUMBQ_DIR}/bootstraps/${BOOTSTRAP_NAME}"
+DUMBQ_UTILS_DIR="${DUMBQ_DIR}/client/utils"
+DUMBQ_LOGCAT_BIN="${DUMBQ_UTILS_DIR}/dumbq-logcat"
+DUMBQ_METRICS_BIN="${DUMBQ_UTILS_DIR}/dumbq-metrics"
+
+# CMS Paths
+CMS_PUBLIC_WWW_TGZ="/cvmfs/sft.cern.ch/lcg/external/experimental/t4t-webapp/t4t-webapp.tgz"
+CMS_HOME="${CMS_HOME}"
+CMS_AGENT="${CMS_HOME}/agent"
+CMS_WEBAPP="${CMS_HOME}/WebApp"
+CMS_PUBLIC_WWW="${CMS_PUBLIC_WWW}"
+CMS_PUBLIC_WWW_LOGDIR=${CMS_PUBLIC_WWW}/logs
+CMS_PUBLIC_WWW_JOBDIR=${CMS_PUBLIC_WWW}/job
+BOINC_PATH="/home/boinc/"
+CMS_PATH="${BOINC_PATH}/CMSRun/"
+
+# Log files names
+STDOUT="stdout"
+STDERR="stderr"
+CMS_STDOUT_LOG="cmsRun-${STDOUT}.log"
+CMS_STDERR_LOG="cmsRun-${STDERR}.log"
+CMS_ANALYSIS_LOG="CMSRunAnalysisLog.txt"
+BOINC_STDOUT_LOG="CMSJobAgent-${STDOUT}.log"
+BOINC_STDERR_LOG="CMSJobAgent-${STDERR}.log"
+
+# Log files
+BOINC_STDOUT="${BOINC_PATH}/${STDOUT}"
+BOINC_STDERR="${BOINC_PATH}/${STDERR}"
+CMS_STDOUT="${CMS_PATH}/${CMS_STDOUT_LOG}"
+CMS_STDERR="${CMS_PATH}/${CMS_STDERR_LOG}"
+
+
+# 0) Redirect and start logcat 
+# -----------------------------
+
+# Create missing directories
+mkdir -p ${CMS_PUBLIC_WWW_LOGDIR}
+mkdir -p ${CMS_PUBLIC_WWW_JOBDIR}
+
+(
+   # Start logcat with all the interesting log files
+   # This process will write everything in the public log files:
+   #   - bootstrap-out.log
+   #   - bootstrap-err.log
+  ${DUMBQ_LOGCAT_BIN} \
+    --prefix="[%d/%m/%y %H:%M:%S] " \
+    ${CMS_PUBLIC_WWW_LOGDIR}/bootstrap-out[green] \
+    ${CMS_PUBLIC_WWW_LOGDIR}/bootstrap-err.log[magenta] \
+    ${BOINC_STDOUT}[green] \
+    ${BOINC_STDERR}[red] \
+    ${CMS_STDOUT}[green] \
+    ${CMS_STDERR}[red] \
+	${CMS_PATH}/${CMS_ANALYSIS_LOG}[white] \
+	# There is only out, not err 
+	"/tmp/mcplots-job.out"[cyan] 
+)&
+
+# Redirect stdout/err
+exec 2>${CMS_PUBLIC_WWW_LOGDIR}/bootstrap-err.log >${CMS_PUBLIC_WWW_LOGDIR}/bootstrap-out.log
+
+# 1) Installing CMS@Home app
+# --------------------------
+
+# Ensure the floppy drive is readable for a user
+chmod +r /dev/fd0
+
+# Copy certificates locally and install the BOINC CA
+rm -f /etc/grid-security/certificates
+cp -r /cvmfs/grid.cern.ch/etc/grid-security/certificates /etc/grid-security/
+cp -r ${CMS_HOME_AGENT}/boinc-ca/* /etc/grid-security/certificates/
+
+# Plugin globus commands
+ln -sf /cvmfs/grid.cern.ch/glite/globus/bin/grid-proxy-init /usr/bin/
+ln -sf /cvmfs/grid.cern.ch/glite/globus/bin/grid-proxy-info /usr/bin/
+
+# Temp fix for contextulization issue
+echo "export CMS_LOCAL_SITE=/etc/cms/SITECONF/BOINC" >> /etc/cvmfs/config.d/cms.cern.ch.local
+cvmfs_config reload
+
+# Manual SITECONF
+mkdir -p /etc/cms/SITECONF/BOINC/{JobConfig,PhEDEx}
+ln -sf /etc/cms/SITECONF/BOINC /etc/cms/SITECONF/local
+ln -sf ${CMS_HOME_AGENT}/site-local-config.xml  /etc/cms/SITECONF/BOINC/JobConfig/site-local-config.xml
+ln -sf ${CMS_HOME_AGENT}/storage.xml /etc/cms/SITECONF/BOINC/JobConfig/storage.xml
+
+# Add index to the WWW public folder
+cat ${CMS_HOME_WEBAPP}/index.html > ${CMS_PUBLIC_WWW}/index.html
+
+# Put the bootlog to the Web logs
+cat /var/log/boot.log > ${CMS_PUBLIC_WWW_LOGDIR}/boot.log
+
+# Start the Web server (ported from CMS script)
+# service httpd start -> It should not work. It's not tested, though
+
+
+# 2) Add the T4T application
+# --------------------------
+
+# Unzip the t4t-webapp
+/bin/tar zxvf $CMS_PUBLIC_WWW_TGZ -C $CMS_PUBLIC_WWW > /dev/null 2>&1
+
+
+# 3) Start metrics monitor and CMS-Agent
+# --------------------------------------
+
+# Log dumb metadata for debug purposes
+if [ -f /var/lib/dumbq-meta ]; then
+	echo "--[ Global Metadata ]-------------------------"
+	cat /var/lib/dumbq-meta
+	echo "----------------------------------------------"
+fi
+
+# Start the log-monitoring agent that will update the dumbq metrics file
+python ${BOOTSTRAP_DIR}/bin/mcprod-monitor&
+
+# Include DUMBQ binary dir in environment
+export PATH="${PATH}:${DUMBQ_UTILS_DIR}"
+
+# Setup the CMS-Agent cron job
+echo "* * * * * boinc ${CMS_AGENT}/CMSJobAgent.sh" > /etc/cron.d/cms-agent
+service crond restart

--- a/bootstraps/cms-webfest/vm-contextualization
+++ b/bootstraps/cms-webfest/vm-contextualization
@@ -1,0 +1,15 @@
+[amiconfig]
+plugins=cernvm
+
+[cernvm]
+organisations=CMS
+repositories=cms,grid
+shell=/bin/bash
+config_url=http://cernvm.cern.ch/config
+services=cvmfs,network,
+users=boinc:cms:$6$TNRr1Qpj$O7AlaBX5TBkh2v6NkzIQQaHLIy/7lf/JS0WNLgh6HofxcMun0KSGqmHSkok8V9W/U9pCMmxQGRunrQPtGTBGG/
+edition=Batch
+
+[ucernvm-begin]
+cvmfs_branch=cernvm-prod.cern.ch
+[ucernvm-end]


### PR DESCRIPTION
Here you have the script adapted for the CMS jobs.

I haven't still figured it out the way to specify the vm contextualization. I think this should be done in the server file by you, just adding the bootstrap file with the repositories it depends on.

However, in the vm-contextualization file I add, there is more specific information that could be necessary to apply to the VM once DumbQ creates it. That's why, just in case, I add it to the pull request.

Let me know if something is missing.

Cheers,
Jorge Vicente Cantero
